### PR TITLE
fix print msg error when msg is not RemotingCommand instance

### DIFF
--- a/lts-core/src/main/java/com/github/ltsopensource/remoting/lts/LtsCodecFactory.java
+++ b/lts-core/src/main/java/com/github/ltsopensource/remoting/lts/LtsCodecFactory.java
@@ -45,7 +45,7 @@ public class LtsCodecFactory {
                     RemotingHelper.closeChannel(c);
                 }
             } else {
-                LOGGER.error("Message is instance of " + RemotingCommand.class.getName());
+                LOGGER.error("Message is not instance of " + RemotingCommand.class.getName());
             }
             return null;
         }


### PR DESCRIPTION
fix print msg error when msg is not RemotingCommand instance