### PR TITLE
解决将已经正常完成的任务错误识别为死任务的问题

### DIFF
--- a/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/sender/JobSender.java
+++ b/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/sender/JobSender.java
@@ -68,7 +68,7 @@ public class JobSender {
 
             // IMPORTANT: 这里要先切换队列
             try {
-                jobPo.setGmtModified(jobPo.getGmtCreated());
+                jobPo.setGmtModified(SystemClock.now());
                 appContext.getExecutingJobQueue().add(jobPo);
             } catch (DupEntryException e) {
                 LOGGER.warn("ExecutingJobQueue already exist:" + JSON.toJSONString(jobPo));


### PR DESCRIPTION
由于任务从“等待执行队列”向“执行中队列”切换时，任务的gmt_created时间是任务被放入“等待执行队列”的时间，如果任务在等待执行队列滞留时间超过30秒，那么被放入“执行中队列”的每一个任务，都会被jobtracker认为疑似死任务，这时jobtracker会向tasktracker请求这些疑似死任务在tasktracker中的状态，如果恰好这时有的任务已经执行完成，tasktracker就会返回这个任务的isRunning为0，jobtracker就会将这个任务识别为死任务，进行修复重新执行。但实际上这个任务是已经执行完成的，造成任务重复执行的问题。
修改的思路是，在com.github.ltsopensource.jobtracker.sender.JobSender进行任务切换时（从“等待执行队列”向“执行中队列”切换），更新gmt_modified为当前时间，在MysqlExecutingJobQueue.getDeadJobs方法中，判断gmt_modified（将gmt_created改为gmt_modified）的时间晚于deadline，实现疑似死任务的准确判断。