### PR TITLE
bugfix:NullPointerException when upgrade from 1.6.9 to 1.7.0

### DIFF
--- a/lts-core/src/main/java/com/github/ltsopensource/core/protocol/command/JobPushRequest.java
+++ b/lts-core/src/main/java/com/github/ltsopensource/core/protocol/command/JobPushRequest.java
@@ -3,6 +3,7 @@ package com.github.ltsopensource.core.protocol.command;
 import com.github.ltsopensource.core.domain.JobMeta;
 import com.github.ltsopensource.remoting.annotation.NotNull;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -14,6 +15,14 @@ public class JobPushRequest extends AbstractRemotingCommandBody {
 	
 	@NotNull
     private List<JobMeta> jobMetaList;
+
+    /**
+     *  jobClient(lts-1.7.0) deserialize  message from jobTracker (lts-1.6.9)
+     */
+	@Deprecated
+    public void setJobMeta(JobMeta jobMeta) {
+        this.jobMetaList = Arrays.asList(jobMeta);
+    }
 
     public List<JobMeta> getJobMetaList() {
         return jobMetaList;


### PR DESCRIPTION
**版本升级异常**
**升级前版本 **  jobTracker1.6.9  taskTracker1.6.9
**升级过程：** jobTracker1.6.9  taskTracker1.7.0
**发生异常：**
```
19:51:37.470 [AbstractClientNode-thread-8] ERROR c.g.l.remoting.AbstractRemoting -  [LTS] process request exception, lts version: 1.7.0, current host: 192.168.0.71
java.lang.NullPointerException: null
	at com.github.ltsopensource.tasktracker.processor.JobPushProcessor.processRequest(JobPushProcessor.java:92) ~[lts-1.7.0.jar:na]
	at com.github.ltsopensource.tasktracker.processor.RemotingDispatcher.processRequest(RemotingDispatcher.java:37) ~[lts-1.7.0.jar:na]
	at com.github.ltsopensource.remoting.AbstractRemoting$1.run(AbstractRemoting.java:73) ~[lts-1.7.0.jar:na]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_112]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_112]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_112]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_112]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_112]
```
**报错原因：**
jobClient(lts-1.7.0) deserialize  message exception from jobTracker (lts-1.6.9)
JobPushRequest.java中的jobMeta在版本升级后1.6.9->1.7.0,因性能优化改成了jobMetaList，
导致netty传输的报文不匹配

**处理：**
如merge 所示，让jobTracker1.6.9推送的消息JobPushRequest在taskTraker1.7.0中正常反序列化

