### PR TITLE
解决repeat job两个bug：job多执行一次；第一次执行不按照job的first triggertime执行

### DIFF
--- a/lts-core/src/main/java/com/github/ltsopensource/queue/support/NonRelyJobUtils.java
+++ b/lts-core/src/main/java/com/github/ltsopensource/queue/support/NonRelyJobUtils.java
@@ -81,10 +81,13 @@ public class NonRelyJobUtils {
         }
         // 计算出应该重复的次数
         int repeatedCount = Long.valueOf((lastGenerateTime.getTime() - firstTriggerTime) / jobPo.getRepeatInterval()).intValue();
+        if (repeatedCount <= 0) {
+            repeatedCount = 1; //repeatedCount从1开始
+        }
 
         boolean stop = false;
         while (!stop) {
-            Long nextTriggerTime = firstTriggerTime + repeatedCount * repeatInterval;
+            Long nextTriggerTime = firstTriggerTime + (repeatedCount - 1) * repeatInterval; //第一次执行时间点应该是firstTriggerTime
 
             if (nextTriggerTime <= endTime &&
                     (repeatCount == -1 || repeatedCount <= repeatCount)) {

--- a/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/complete/JobFinishHandler.java
+++ b/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/complete/JobFinishHandler.java
@@ -117,7 +117,7 @@ public class JobFinishHandler {
             // 可能任务队列中改条记录被删除了
             return;
         }
-        if (jobPo.getRepeatCount() != -1 && jobPo.getRepeatedCount() >= jobPo.getRepeatCount()) {
+        if (jobPo.getRepeatCount() != -1 && (jobPo.getRepeatedCount() + 1) >= jobPo.getRepeatCount()) {  //最后一次执行时 repeatedCount+1=repeatCount
             // 已经重试完成, 那么删除, 这里可以不用check可执行队列是否还有,因为这里依赖的是计数
             appContext.getRepeatJobQueue().remove(jobPo.getJobId());
             jobRemoveLog(jobPo, "Repeat");
@@ -137,7 +137,7 @@ public class JobFinishHandler {
             // 可能任务队列中改条记录被删除了
             return;
         }
-        if (jobPo.getRepeatCount() != -1 && jobPo.getRepeatedCount() >= jobPo.getRepeatCount()) {
+        if (jobPo.getRepeatCount() != -1 && (jobPo.getRepeatedCount() + 1) >= jobPo.getRepeatCount()) {  //最后一次执行时 repeatedCount+1=repeatCount
             // 已经重试完成, 那么删除
             appContext.getRepeatJobQueue().remove(jobId);
             jobRemoveLog(jobPo, "Repeat");
@@ -156,7 +156,7 @@ public class JobFinishHandler {
         }
         long nexTriggerTime = JobUtils.getRepeatNextTriggerTime(jobPo);
         try {
-            jobPo.setRepeatedCount(repeatedCount);
+            jobPo.setRepeatedCount(repeatedCount + 1); //再生成可执行job时，从RepeatJobQueue更新后的repeatedCount再加1
             jobPo.setTaskTrackerIdentity(null);
             jobPo.setIsRunning(false);
             jobPo.setTriggerTime(nexTriggerTime);

--- a/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/support/JobReceiver.java
+++ b/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/support/JobReceiver.java
@@ -228,6 +228,7 @@ public class JobReceiver {
             if (appContext.getExecutingJobQueue().getJob(jobPo.getTaskTrackerNodeGroup(), jobPo.getTaskId()) == null) {
                 // 2. add to executable queue
                 try {
+                    jobPo.setRepeatedCount(1); //第一次job的repeatedCount为1
                     jobPo.setInternalExtParam(Constants.EXE_SEQ_ID, JobUtils.generateExeSeqId(jobPo));
                     appContext.getExecutableJobQueue().add(jobPo);
                 } catch (DupEntryException e) {


### PR DESCRIPTION
使用目前的代码，会有两个问题：
1. 不依赖上一周期的repeat job的triggertime不生效，实际上是按照第二次的执行时间开始执行的。
2. 所有repeat job一直会多执行一次，原因是JobFinishHandler里面处理repeat 的job有误，多算了一次。在最后一次执行时，repeatCount-repeatedCount应该为1。


我改了3处，修复了这两个bug：job多执行一次；第一次执行不按照job的first triggertime执行。

说明：repeat job queue 里面的repeatedCount是已经重复的次数，从0开始，最大值为repeatCount（没达到最大值时，job执行完成，就会被删掉）；repeatCount可重复次数，从0开始。
可执行job queue里的repeatedCount是从1开始的，最大值repeatCount。
只有可执行job执行完成了，repeat job queue里面的repeatCount才被更新成刚执行完job的repeatedCount。

举例：假如可执行job列表里的repeatedCount为2，那么此时RepeatJobQueue里面的repeatCount值应该为1。当这个可执行job执行完后，RepeatJobQueue里面的repeatCount才更新为2，再次生成的可执行repeat job里的repeatedCount应该为3。

