### PR TITLE
解决getNodeGroup不能分页的bug

### DIFF
--- a/lts-admin/src/main/java/com/github/ltsopensource/admin/web/api/NodeApi.java
+++ b/lts-admin/src/main/java/com/github/ltsopensource/admin/web/api/NodeApi.java
@@ -54,11 +54,8 @@ public class NodeApi extends AbstractMVC {
     }
 
     @RequestMapping("node-group-get")
-    public RestfulResponse getNodeGroup(NodeGroupRequest request) {
+    public RestfulResponse getNodeGroup(NodeGroupGetReq nodeGroupGetReq) {
         RestfulResponse response = new RestfulResponse();
-        NodeGroupGetReq nodeGroupGetReq = new NodeGroupGetReq();
-        nodeGroupGetReq.setNodeGroup(request.getNodeGroup());
-        nodeGroupGetReq.setNodeType(request.getNodeType());
         PaginationRsp<NodeGroupPo> paginationRsp = appContext.getNodeGroupStore().getNodeGroup(nodeGroupGetReq);
 
         response.setResults(paginationRsp.getResults());


### PR DESCRIPTION
解决getNodeGroup不能分页的bug.

NodeGroupGetReq 对象里面带的分页参数丢失了。