### PR TITLE
[FIX BUG]ExecutingDeadJobChecker停止

### DIFF
--- a/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/support/checker/ExecutableDeadJobChecker.java
+++ b/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/support/checker/ExecutableDeadJobChecker.java
@@ -29,7 +29,7 @@ public class ExecutableDeadJobChecker {
     // 1 分钟还锁着的，说明是有问题的
     private static final long MAX_TIME_OUT = 60 * 1000;
 
-    private final ScheduledExecutorService FIXED_EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1, new NamedThreadFactory("LTS-ExecutableJobQueue-Fix-Executor", true));
+    private ScheduledExecutorService FIXED_EXECUTOR_SERVICE;
 
     private JobTrackerAppContext appContext;
 
@@ -43,6 +43,7 @@ public class ExecutableDeadJobChecker {
     public void start() {
         try {
             if (start.compareAndSet(false, true)) {
+                FIXED_EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1, new NamedThreadFactory("LTS-ExecutableJobQueue-Fix-Executor", true));
                 scheduledFuture = FIXED_EXECUTOR_SERVICE.scheduleWithFixedDelay(new Runnable() {
                     @Override
                     public void run() {

--- a/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/support/checker/ExecutingDeadJobChecker.java
+++ b/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/support/checker/ExecutingDeadJobChecker.java
@@ -50,7 +50,7 @@ public class ExecutingDeadJobChecker {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ExecutingDeadJobChecker.class);
 
-    private final ScheduledExecutorService FIXED_EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1, new NamedThreadFactory("LTS-ExecutingJobQueue-Fix-Executor", true));
+    private ScheduledExecutorService FIXED_EXECUTOR_SERVICE;
 
     private JobTrackerAppContext appContext;
     private JobTrackerMStatReporter stat;
@@ -73,6 +73,7 @@ public class ExecutingDeadJobChecker {
                     fixCheckPeriodSeconds = 5 * 60;
                 }
 
+                FIXED_EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1, new NamedThreadFactory("LTS-ExecutingJobQueue-Fix-Executor", true));
                 scheduledFuture = FIXED_EXECUTOR_SERVICE.scheduleWithFixedDelay(new Runnable() {
                     @Override
                     public void run() {

--- a/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/support/checker/FeedbackJobSendChecker.java
+++ b/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/support/checker/FeedbackJobSendChecker.java
@@ -29,7 +29,7 @@ public class FeedbackJobSendChecker {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FeedbackJobSendChecker.class);
 
-    private ScheduledExecutorService RETRY_EXECUTOR_SERVICE = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("LTS-FeedbackJobSend-Executor", true));
+    private ScheduledExecutorService RETRY_EXECUTOR_SERVICE;
     private ScheduledFuture<?> scheduledFuture;
     private AtomicBoolean start = new AtomicBoolean(false);
     private ClientNotifier clientNotifier;
@@ -68,6 +68,7 @@ public class FeedbackJobSendChecker {
     public void start() {
         try {
             if (start.compareAndSet(false, true)) {
+                RETRY_EXECUTOR_SERVICE = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory("LTS-FeedbackJobSend-Executor", true));
                 scheduledFuture = RETRY_EXECUTOR_SERVICE.scheduleWithFixedDelay(new Runner()
                         , 30, 30, TimeUnit.SECONDS);
             }


### PR DESCRIPTION
当某个JobTracker从Master变成Slave再变成Master时，Checker启动失败。
从Master变成Slave时会stop掉Checker中的线程池，而重新变成Master时，线程池已经关闭且不会创建新的线程池