### PR TITLE
修复Repeatjob执行完成后不能删除job（不依赖上周期）和不能更新repeatedCount（依赖上周期）的bug

### DIFF
--- a/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/complete/JobFinishHandler.java
+++ b/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/complete/JobFinishHandler.java
@@ -127,7 +127,11 @@ public class JobFinishHandler {
         // 如果当前完成的job是重试的,那么不要增加repeatedCount
         if (!isRetryForThisTime) {
             // 更新repeatJob的重复次数
-            appContext.getRepeatJobQueue().incRepeatedCount(jobPo.getJobId());
+            final int jobQueueRepeatedCount = appContext.getRepeatJobQueue().incRepeatedCount(jobPo.getJobId());
+            if (jobQueueRepeatedCount >= jobPo.getRepeatCount()) {
+                appContext.getRepeatJobQueue().remove(jobPo.getJobId());
+                jobRemoveLog(jobPo, "Repeat");
+            }
         }
     }
 

--- a/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/complete/JobRetryHandler.java
+++ b/lts-jobtracker/src/main/java/com/github/ltsopensource/jobtracker/complete/JobRetryHandler.java
@@ -87,7 +87,9 @@ public class JobRetryHandler {
                             nextRetryTriggerTime = nexTriggerTime;
                             jobPo = repeatJobPo;
                         } else {
-                            jobPo.setInternalExtParam(Constants.IS_RETRY_JOB, Boolean.TRUE.toString());
+                            if(jobPo.getRetryTimes() < repeatJobPo.getMaxRetryTimes()) { //最后一次重试时，这个参数不能设置，为了在finishHandler时能执行到incRepeatedCount
+                               jobPo.setInternalExtParam(Constants.IS_RETRY_JOB, Boolean.TRUE.toString());
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
两个bug：

1. 有可能多个 不依赖上一周期的repeat job会同时执行（tasktracker可能停掉一段时间后重启），那么就会在finishNoReplyPrevRepeatJob前半部分删除不了这个repeat job，所以在finishNoReplyPrevRepeatJob后面需要根据jobQueueRepeatedCount判断再次删除下。


2. 假如依赖上一个周期的repeatjob设置了重试次数，并且job一直执行失败。按照原先的逻辑，IS_RETRY_JOB这个内部params会一直是true，当这个job执行完足够的重试次数后，在JobFinishHanler的finishRepeatJob方法中，
拿到的isRetryForThisTime是true，就无法调用到appContext.getRepeatJobQueue().incRepeatedCount，就无法更新repeatedCount。
解决方法：最后一次重试时，这个参数IS_RETRY_JOB不能设置为true，为了在JobFinishHanler时能执行到incRepeatedCount逻辑。
