### PR TITLE
reSubscribe .有时候先下线一个jobtracker，后上线这个jobtracker--卢松

### DIFF
--- a/lts-admin/src/main/java/com/github/ltsopensource/admin/cluster/BackendRegistrySrv.java
+++ b/lts-admin/src/main/java/com/github/ltsopensource/admin/cluster/BackendRegistrySrv.java
@@ -92,8 +92,8 @@ public class BackendRegistrySrv {
                         LOGGER.info("ADD NODE " + nodes);
                         break;
                     case REMOVE:
-                        appContext.getNodeMemCacheAccess().removeNode(nodes);
-                        LOGGER.info("REMOVE NODE " + nodes);
+                        reSubscribe();
+                        LOGGER.info("Resubscribe NODE " );
                         break;
                 }
                 // 记录日志


### PR DESCRIPTION
reSubscribe .有时候先下线一个jobtracker，后上线这个jobtracker，
结果这边收到的事件是先add，后remove，导致页面添加job时出现“jobtracker找不到”

改造方式：remove事件时重新订阅。